### PR TITLE
Set upper limit for log level so no emerg logs

### DIFF
--- a/dev/HAPROXY_HEAD
+++ b/dev/HAPROXY_HEAD
@@ -1,7 +1,7 @@
 global
   daemon
-  log /dev/log local0
-  log /dev/log local1 notice
+  log /dev/log local0 debug alert
+  log /dev/log local1 notice alert
   maxconn 50000
   tune.ssl.default-dh-param 2048
   ssl-default-bind-ciphers EECDH+CHACHA20:EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:!MD5:!DSS;

--- a/marathon.yml
+++ b/marathon.yml
@@ -6,7 +6,8 @@ args: [
     "sse",
     "--group={{marathon_group_name}}",
     "--marathon={{marathon_url}}",
-    "--auth-credentials={{marathon_creds}}"
+    "--auth-credentials={{marathon_creds}}",
+    "--syslog-socket=/dev/log"
     ]
 container:
   docker:
@@ -20,6 +21,11 @@ container:
       -
         key: "label"
         value: "APP_BUILD={{version}}"
+  volumes:
+  -
+    containerPath: /dev/log
+    hostPath: /dev/log
+    mode: RW
 env:
   NC_ID: {{nutcracker_id}}
   NC_KEY: {{nutcracker_key}}


### PR DESCRIPTION
Set alert as highest level of logging to syslog. This will stop journald logging emerg messages to console, as they won't be sent to syslog socket. 

```
log <address> [len <length>] [format <format>] <facility> [max level [min level]]
```